### PR TITLE
Add Discord Server to Navigation

### DIFF
--- a/.kahi-docs/application.config.ts
+++ b/.kahi-docs/application.config.ts
@@ -30,6 +30,7 @@ export default define_application({
     },
 
     metadata: {
+        discord: "https://discord.com/invite/JvUbmJvUBG",
         version: PACKAGE_FRAMEWORK.version,
     },
 });

--- a/.kahi-docs/navigation.config.ts
+++ b/.kahi-docs/navigation.config.ts
@@ -1,5 +1,6 @@
 import {Book} from "svelte-feather/components/Book";
 import {Code} from "svelte-feather/components/Code";
+import {MessageCircle} from "svelte-feather/components/MessageCircle";
 import {Package} from "svelte-feather/components/Package";
 
 import {define_navigation} from "@kahi-docs/config";
@@ -9,6 +10,7 @@ export default define_navigation({
         {href: "/docs/framework/getting-started", text: "Documentation", icon: Book},
         {href: "https://github.com/novacbn/kahi-ui", text: "Source", icon: Code},
         {href: "https://github.com/novacbn/kahi-ui/releases", text: "Releases", icon: Package},
+        {href: "/chat", text: "Chat", icon: MessageCircle},
     ],
 
     documentation: [

--- a/src/components/navigation/AppNavigation.svelte
+++ b/src/components/navigation/AppNavigation.svelte
@@ -148,6 +148,7 @@
                 <TextInput
                     type="search"
                     placeholder="[CTRL+/] Search"
+                    size="small"
                     variation="block"
                     align="center"
                     on:focus={on_search_focus}
@@ -178,6 +179,7 @@
             <MenuNavigation
                 items={_items}
                 orientation="horizontal"
+                sizing="small"
                 hidden={["mobile", "tablet", "desktop"]}
             />
         </Omni.Section>
@@ -194,7 +196,7 @@
     :global(.app-navigation) {
         grid-area: header;
 
-        height: 5rem;
+        height: 4.4rem;
     }
 
     :global(.app-navigation) :global(header) :global(small) {

--- a/src/components/navigation/AsideNavigation.svelte
+++ b/src/components/navigation/AsideNavigation.svelte
@@ -42,7 +42,7 @@
 >
     <!-- TODO: Margin modifier is temp until Framework update to fix it -->
     <Aside.Section margin_bottom="none" padding_y="large">
-        <MenuNavigation {items} />
+        <MenuNavigation sizing="small" {items} />
     </Aside.Section>
 
     <ContextButton size="huge" hidden={["desktop", "widescreen"]}>
@@ -61,11 +61,11 @@
 
     :global(.aside-navigation) {
         position: sticky !important;
-        top: 5rem;
+        top: 4.4rem;
 
         grid-area: aside;
 
-        width: 20rem;
+        width: 18rem;
         height: calc(100vh - 5rem);
     }
 

--- a/src/components/navigation/MenuNavigation.svelte
+++ b/src/components/navigation/MenuNavigation.svelte
@@ -3,6 +3,7 @@
     import type {
         DESIGN_HIDDEN_ARGUMENT,
         DESIGN_ORIENTATION_VERTICAL_ARGUMENT,
+        DESIGN_SIZING_ARGUMENT,
     } from "@kahi-ui/framework";
     import {Badge, Menu, Spacer} from "@kahi-ui/framework";
     import type {Page} from "@sveltejs/kit";
@@ -13,6 +14,7 @@
     export let items: INavigationMenu[] = [];
     export let hidden: DESIGN_HIDDEN_ARGUMENT = false;
     export let orientation: DESIGN_ORIENTATION_VERTICAL_ARGUMENT | undefined = undefined;
+    export let sizing: DESIGN_SIZING_ARGUMENT | undefined = undefined;
 
     function is_current(page: Page, anchor: INavigationAnchor): boolean {
         if (is_internal_url(anchor.href)) {
@@ -23,7 +25,7 @@
     }
 </script>
 
-<Menu.Container {hidden} {orientation}>
+<Menu.Container {hidden} {orientation} {sizing}>
     {#each items as item, index (index)}
         {#if "separator" in item}
             {#if item.separator}

--- a/src/routes/chat.svelte
+++ b/src/routes/chat.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+    import {Anchor, Ellipsis, Hero} from "@kahi-ui/framework";
+
+    import {applicationconfig} from "@kahi-docs/shared";
+
+    $: _href = $applicationconfig.metadata.discord as string;
+</script>
+
+<svelte:head>
+    <title>
+        {$applicationconfig.application.description} :: {$applicationconfig.application.title}
+    </title>
+
+    <meta http-equiv="refresh" content="0;{_href}" />
+</svelte:head>
+
+<Hero.Container palette="dark" padding_y="huge" height="viewport-100">
+    <Hero.Header>Redirecting<Ellipsis /></Hero.Header>
+    <Hero.Footer>
+        Click to goto the Kahi UI
+        <Anchor href={_href} rel="noopener noreferrer" target="_blank">Discord server</Anchor>
+        invite.
+    </Hero.Footer>
+</Hero.Container>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -19,6 +19,4 @@
     {#if $partialsconfig.Landing}
         <svelte:component this={$partialsconfig.Landing} />
     {/if}
-
-    <svelte:fragment slot="footer" />
 </LandingLayout>


### PR DESCRIPTION
# CHANGELOG

- Adjusted navigation sizing to use smaller buttons, links, etc.
- Added `/chat` route which uses `<meta http-equiv="refresh" />` to redirect to invite.
- Added `/chat` route to navigation items.