### PR TITLE
Touchup Resources Documentation

### DIFF
--- a/.kahi-docs/navigation.config.ts
+++ b/.kahi-docs/navigation.config.ts
@@ -16,11 +16,7 @@ export default define_navigation({
     documentation: [
         {
             separator: "Resources",
-            items: [
-                {href: "/docs/resources/icons"},
-                {href: "/docs/resources/official"},
-                {href: "/docs/resources/community"},
-            ],
+            items: [{href: "/docs/resources/official"}, {href: "/docs/resources/community"}],
         },
 
         {

--- a/content/docs/resources/community.md
+++ b/content/docs/resources/community.md
@@ -1,5 +1,15 @@
 # Community
 
-We have a community [Discord Server](https://discord.com/invite/JvUbmJvUBG) where you can ask questions and talk to other kahi developers.
+Below you can find resources by other developers made with Kahi UI or related.
 
-Below you can find resources by other developers made with Kahi UI.
+## Discussion / Support
+
+> Other community channels besides the main repository for talking about or getting help with Kahi UI.
+
+-   [Discord](https://discord.com/invite/JvUbmJvUBG) — Official support Discord, where you can talk to other Kahi UI developers.
+
+## Icons
+
+> Iconography projects that have been shown to work well with Kahi UI.
+
+-   [Feather Icons](https://feathericons.com/) — Lightweight SVG Icons, used by this documentation site.

--- a/content/docs/resources/icons.md
+++ b/content/docs/resources/icons.md
@@ -1,7 +1,0 @@
-# Icons
-
-By default the Kahi UI **DOES NOT** ship with Icons, although it **DOES** support inserting Icons at key-locations or make it possible to insert your own. Here are some suggestions of Icon libraries that have been known to work well with the Framework:
-
--   [Feather Icons](https://feathericons.com/) — Lightweight SVG Icons, used by this documentation site.
-
-    -   [`novacbn/svelte-feather`](https://novacbn.github.io/svelte-feather) — Svelte bindings for Feather, also used by this documentation site. _(disclaimer: made by me)_

--- a/content/docs/resources/official.md
+++ b/content/docs/resources/official.md
@@ -4,8 +4,12 @@ Below you can find resources made maintained by Kahi UI contributors.
 
 ## Showcase
 
+> Projects that show off the Kahi UI framework.
+
 -   [kahi-framework/kahi-ui.nbn.dev](https://github.com/kahi-framework/kahi-ui.nbn.dev) — Official documentation site.
 
 ## Templates
+
+> Projects that can be used as a basis for your own project, showing how to integrate with various software.
 
 -   [kahi-framework/kahi-ui-template-sveltekit](https://github.com/kahi-framework/kahi-ui-template-sveltekit) — Official template for SvelteKit based on the `npm init svelte@next` starter.


### PR DESCRIPTION
# CHANGELOG

- Added section descriptions to "Official" Resources documentation.
- Reformatted "Community" Resources documentation.
- Removed "Icons" Resources documentation and migrated to "Community" Resources documentation.